### PR TITLE
feat: :alien: Update to use Intl API in place of functions deprecates…

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -46,8 +46,7 @@ dynamic-import@0.7.3
 msavin:mongol@10.0.1
 ostrio:flow-router-extra
 accounts-password@2.4.0
-universe:i18n
-universe:i18n-blaze
+universe:i18n@2.0.0
 softwarerero:accounts-t9n
 babrahams:accounts-ldap
 promise@0.12.2

--- a/imports/config/accounts.js
+++ b/imports/config/accounts.js
@@ -1,6 +1,6 @@
 import { GlobalSettings } from "/imports/config/GlobalSettings";
 import { LdapSettings } from "/imports/config/LdapSettings";
-import { I18nHelper } from "/imports/helpers/i18n";
+import { I18nHelper, getLocaleCodes } from "/imports/helpers/i18n";
 import { Accounts } from "meteor/accounts-base";
 import { Meteor } from "meteor/meteor";
 import { T9n } from "meteor/softwarerero:accounts-t9n";
@@ -15,7 +15,7 @@ import { AccountsTemplates } from "meteor/useraccounts:core";
 // currently selected language. In case you'd like to specify a key which is not
 // already provided by accounts-t9n you can always map your own keys.
 
-const availLanguages = i18n.getLanguages();
+const availLanguages = getLocaleCodes();
 
 for (const lang of availLanguages) {
   T9n.map(lang, {

--- a/imports/config/accounts.js
+++ b/imports/config/accounts.js
@@ -18,7 +18,7 @@ import { AccountsTemplates } from "meteor/useraccounts:core";
 const availLanguages = getLocaleCodes();
 
 for (const lang of availLanguages) {
-  T9n.map(lang, {
+  T9n.forEach(lang, {
     custom: {
       usernamePlaceholder: i18n.__("Accounts.usernamePlaceholder", {
         _locale: lang,
@@ -160,7 +160,7 @@ if (Meteor.isServer) {
     await I18nHelper.setLanguageLocale();
   });
 
-  Accounts.onLogout(async function () {
+  Accounts.onLogout(async () => {
     // reset to browser's locale after logout of user
     await I18nHelper.setLanguageLocale();
   });

--- a/imports/config/accounts.js
+++ b/imports/config/accounts.js
@@ -1,6 +1,6 @@
 import { GlobalSettings } from "/imports/config/GlobalSettings";
 import { LdapSettings } from "/imports/config/LdapSettings";
-import { I18nHelper, getLocaleCodes } from "/imports/helpers/i18n";
+import { getLocaleCodes, I18nHelper } from "/imports/helpers/i18n";
 import { Accounts } from "meteor/accounts-base";
 import { Meteor } from "meteor/meteor";
 import { T9n } from "meteor/softwarerero:accounts-t9n";

--- a/imports/helpers/i18n.js
+++ b/imports/helpers/i18n.js
@@ -150,7 +150,8 @@ export class I18nHelper {
 
   /**
    * Get the language locale for the current user.
-   * If the user is not logged in or the locale is not set, "auto" will be returned.
+   * If the user is not logged in or the locale is not set, "auto" will be
+   * returned.
    * @returns {string} The language locale.
    */
   static getLanguageLocale() {
@@ -166,8 +167,9 @@ export class I18nHelper {
 
   /**
    * Returns the preferred user locale.
-   * If the application is running in an end-to-end test mode, it returns "en-US".
-   * Otherwise, it checks the user's profile locale, and if not available, falls back to the preferred browser locale.
+   * If the application is running in an end-to-end test mode, it returns
+   * "en-US". Otherwise, it checks the user's profile locale, and if not
+   * available, falls back to the preferred browser locale.
    *
    * @returns {string} The preferred user locale.
    */
@@ -186,7 +188,8 @@ export class I18nHelper {
   /**
    * Returns the preferred browser locale.
    * If running in an end-to-end test environment, it returns "en-US".
-   * Otherwise, it tries to determine the preferred browser locale based on the following priorities:
+   * Otherwise, it tries to determine the preferred browser locale based on the
+   * following priorities:
    * 1. Locale determined by I18nHelper._getPreferredBrowserLocaleByPrio()
    * 2. navigator.language
    * 3. navigator.browserLanguage
@@ -209,10 +212,10 @@ export class I18nHelper {
     );
   }
 
-
   /**
    * Retrieves the preferred browser locale based on priority.
-   * @returns {string|undefined} The preferred browser locale or undefined if no browser language is supported.
+   * @returns {string|undefined} The preferred browser locale or undefined if no
+   *     browser language is supported.
    */
   static _getPreferredBrowserLocaleByPrio() {
     if (!navigator.languages || !navigator.languages[0]) {
@@ -249,7 +252,8 @@ export class I18nHelper {
   /**
    * Persists the language preference for the current user.
    *
-   * @param {string} localeCode - The locale code representing the language preference.
+   * @param {string} localeCode - The locale code representing the language
+   *     preference.
    * @returns {void}
    */
   static _persistLanguagePreference(localeCode) {

--- a/imports/helpers/i18n.js
+++ b/imports/helpers/i18n.js
@@ -2,32 +2,57 @@ import { Meteor } from "meteor/meteor";
 import { T9n } from "meteor/softwarerero:accounts-t9n";
 import { i18n } from "meteor/universe:i18n";
 
+/**
+ * Retrieves the canonical locale codes for the supported locales, this array is taken from the current translation files and should be updated if new languages ares added.
+ * @returns {string[]} An array of canonical locale codes.
+ */
+const getLocaleCodes = () => {
+  const locales = ["af", "ar", "ca", "cs", "da", "de", "de-LI", "el", "en", "es", "fi", "fr", "he", "hi", "hu", "it", "ja", "ko", "nl", "no", "pl", "pt", "pt-BR", "ro", "ru", "sr", "sr", "sv", "tr", "uk", "vi", "zh-CN", "zh-TW"];
+  return Intl.getCanonicalLocales(locales);
+};
+// Special case disabled until rest of code is confirmed to work
+ // if (code.toLowerCase() === "de-li") {
+     //   return {
+     //     code,
+     //     codeUI: "de-Fr",
+     //     name: "German (Franconian)",
+     //     nameNative: "Deutsch (Fränggisch)",
 // Only server can provide all available languages via server-side method
 Meteor.methods({
+  /**
+   * Retrieves the available locales.
+   *
+   * @returns {Array} An array of locale objects containing the code, codeUI, name, and nameNative properties.
+   */
   getAvailableLocales() {
     // [{code: "el", name: "Greek", nameNative: "Ελληνικά"}, ...]
-    return i18n.getLanguages().map((code) => {
-      if (code.toLowerCase() === "de-li") {
-        return {
-          code,
-          codeUI: "de-Fr",
-          name: "German (Franconian)",
-          nameNative: "Deutsch (Fränggisch)",
-        };
-      }
+    const languageNamesInEnglish = new Intl.DisplayNames(["en"], { type: "language" });
+    const languageNamesInNativeLanguage = {};
+
+    const localeCodes = getLocaleCodes();
+
+    /**
+     * Returns a locale object based on the provided code.
+     *
+     * @param {string} code - The code representing the locale.
+     * @returns {Object} The locale object containing the code, codeUI, name, and nameNative properties.
+     */
+    const getLocaleObject = (code) => {
+      languageNamesInNativeLanguage[code] = new Intl.DisplayNames([code], {
+        type: "language",
+      });
       return {
         code,
         codeUI: code,
-        name: i18n.getLanguageName(code),
-        nameNative:
-          i18n.getLanguageNativeName(code)[0].toUpperCase() +
-          i18n.getLanguageNativeName(code).slice(1),
+        name: languageNamesInEnglish.of(code),
+        nameNative: languageNamesInNativeLanguage[code].of(code),
       };
-    });
+    };
+    return localeCodes.map(getLocaleObject);
   },
   getAvailableLocaleCodes() {
     // ["el", "de", "zh-CN", "zh-TW"]
-    return i18n.getLanguages();
+    return getLocaleCodes();
   },
 });
 
@@ -167,3 +192,4 @@ export class I18nHelper {
     }
   }
 }
+export { getLocaleCodes };

--- a/imports/helpers/i18n.js
+++ b/imports/helpers/i18n.js
@@ -97,6 +97,11 @@ Meteor.methods({
 });
 
 export class I18nHelper {
+  /**
+   * Array of supported language codes.
+   *
+   * @type {Array<string>}
+   */
   static supportedCodes = [];
 
   // setLanguageLocale() has two modes:
@@ -143,6 +148,11 @@ export class I18nHelper {
       });
   }
 
+  /**
+   * Get the language locale for the current user.
+   * If the user is not logged in or the locale is not set, "auto" will be returned.
+   * @returns {string} The language locale.
+   */
   static getLanguageLocale() {
     if (
       !Meteor.user() ||
@@ -154,6 +164,13 @@ export class I18nHelper {
     return i18n.getLocale();
   }
 
+  /**
+   * Returns the preferred user locale.
+   * If the application is running in an end-to-end test mode, it returns "en-US".
+   * Otherwise, it checks the user's profile locale, and if not available, falls back to the preferred browser locale.
+   *
+   * @returns {string} The preferred user locale.
+   */
   static _getPreferredUserLocale() {
     if (Meteor.settings?.public && Meteor.settings.public.isEnd2EndTest) {
       return "en-US";
@@ -166,6 +183,18 @@ export class I18nHelper {
     );
   }
 
+  /**
+   * Returns the preferred browser locale.
+   * If running in an end-to-end test environment, it returns "en-US".
+   * Otherwise, it tries to determine the preferred browser locale based on the following priorities:
+   * 1. Locale determined by I18nHelper._getPreferredBrowserLocaleByPrio()
+   * 2. navigator.language
+   * 3. navigator.browserLanguage
+   * 4. navigator.userLanguage
+   * If none of the above are available, it defaults to "en-US".
+   *
+   * @returns {string} The preferred browser locale.
+   */
   static _getPreferredBrowserLocale() {
     if (Meteor.settings.isEnd2EndTest) {
       return "en-US";
@@ -180,9 +209,11 @@ export class I18nHelper {
     );
   }
 
-  // If browser has a prioritized array of preferred languages,
-  // we want to determine the "highest" priority language, that
-  // we actually support
+
+  /**
+   * Retrieves the preferred browser locale based on priority.
+   * @returns {string|undefined} The preferred browser locale or undefined if no browser language is supported.
+   */
   static _getPreferredBrowserLocaleByPrio() {
     if (!navigator.languages || !navigator.languages[0]) {
       return undefined; // no browser language, so we can't support any
@@ -215,6 +246,12 @@ export class I18nHelper {
     return undefined; // we don't support any preferred browser languages
   }
 
+  /**
+   * Persists the language preference for the current user.
+   *
+   * @param {string} localeCode - The locale code representing the language preference.
+   * @returns {void}
+   */
   static _persistLanguagePreference(localeCode) {
     if (!Meteor.user() || Meteor.user().isDemoUser) {
       return;

--- a/imports/helpers/i18n.js
+++ b/imports/helpers/i18n.js
@@ -3,30 +3,69 @@ import { T9n } from "meteor/softwarerero:accounts-t9n";
 import { i18n } from "meteor/universe:i18n";
 
 /**
- * Retrieves the canonical locale codes for the supported locales, this array is taken from the current translation files and should be updated if new languages ares added.
+ * Retrieves the canonical locale codes for the supported locales, this array is
+ * taken from the current translation files and should be updated if new
+ * languages ares added.
  * @returns {string[]} An array of canonical locale codes.
  */
 const getLocaleCodes = () => {
-  const locales = ["af", "ar", "ca", "cs", "da", "de", "de-LI", "el", "en", "es", "fi", "fr", "he", "hi", "hu", "it", "ja", "ko", "nl", "no", "pl", "pt", "pt-BR", "ro", "ru", "sr", "sr", "sv", "tr", "uk", "vi", "zh-CN", "zh-TW"];
+  const locales = [
+    "af",
+    "ar",
+    "ca",
+    "cs",
+    "da",
+    "de",
+    "de-LI",
+    "el",
+    "en",
+    "es",
+    "fi",
+    "fr",
+    "he",
+    "hi",
+    "hu",
+    "it",
+    "ja",
+    "ko",
+    "nl",
+    "no",
+    "pl",
+    "pt",
+    "pt-BR",
+    "ro",
+    "ru",
+    "sr",
+    "sr",
+    "sv",
+    "tr",
+    "uk",
+    "vi",
+    "zh-CN",
+    "zh-TW",
+  ];
   return Intl.getCanonicalLocales(locales);
 };
 // Special case disabled until rest of code is confirmed to work
- // if (code.toLowerCase() === "de-li") {
-     //   return {
-     //     code,
-     //     codeUI: "de-Fr",
-     //     name: "German (Franconian)",
-     //     nameNative: "Deutsch (Fränggisch)",
+// if (code.toLowerCase() === "de-li") {
+//   return {
+//     code,
+//     codeUI: "de-Fr",
+//     name: "German (Franconian)",
+//     nameNative: "Deutsch (Fränggisch)",
 // Only server can provide all available languages via server-side method
 Meteor.methods({
   /**
    * Retrieves the available locales.
    *
-   * @returns {Array} An array of locale objects containing the code, codeUI, name, and nameNative properties.
+   * @returns {Array} An array of locale objects containing the code, codeUI,
+   *     name, and nameNative properties.
    */
   getAvailableLocales() {
     // [{code: "el", name: "Greek", nameNative: "Ελληνικά"}, ...]
-    const languageNamesInEnglish = new Intl.DisplayNames(["en"], { type: "language" });
+    const languageNamesInEnglish = new Intl.DisplayNames(["en"], {
+      type: "language",
+    });
     const languageNamesInNativeLanguage = {};
 
     const localeCodes = getLocaleCodes();
@@ -35,7 +74,8 @@ Meteor.methods({
      * Returns a locale object based on the provided code.
      *
      * @param {string} code - The code representing the locale.
-     * @returns {Object} The locale object containing the code, codeUI, name, and nameNative properties.
+     * @returns {Object} The locale object containing the code, codeUI, name,
+     *     and nameNative properties.
      */
     const getLocaleObject = (code) => {
       languageNamesInNativeLanguage[code] = new Intl.DisplayNames([code], {


### PR DESCRIPTION
universe:i18n v2 [deprecates](https://github.com/vazco/meteor-universe-i18n?tab=readme-ov-file#migration-to-v2) several functions we use, notably `getLanguages` , `getLanguageName` and `getLanguageNativeName` 
Have replaced these with the Intl API.
